### PR TITLE
修复“尊敬语和谦逊语”例句中的一处错误

### DIFF
--- a/honorific.html
+++ b/honorific.html
@@ -356,7 +356,7 @@
                     <p>这种其实好理解，你可以想象为一个人变成了动作的那种尊敬状态。接下来你就可以按照う动词 「<span title="なる - 成为" class="popup">なる</span>」的活用规则来活用它了。说实在的，人们很少这么造句。
                     </p>
                     <ul>
-                    <li><span title="せんせい - 老师" class="popup">先生</span>は<span title="どう - 如何" class="popup"></span><em>お<span title="みえる - 变得可见" class="popup">見え</span>に<span title="なる - 成为" class="popup">なります</span></em>か。<br />
+                    <li><span title="せんせい - 老师" class="popup">先生</span>は<em>お<span title="みえる - 变得可见" class="popup">見え</span>に<span title="なる - 成为" class="popup">なります</span></em>か。<br />
                     你见着老师了吗？
                     </li>
                     </ul>


### PR DESCRIPTION
“尊敬形活用法一”的此处例句有一个看起来很迷惑的空的popup：
![image](https://user-images.githubusercontent.com/6646473/147193274-5971cffa-bc00-451c-9c66-8946205a76fc.png)

经比较，英语原文里也有这个空的span标签，可能是原作者忘删了（因为英语原站的空span标签显示不出来）。
从语义上讲例句里也不应该有这个どう，故删去。

另外很感谢您的翻译。不知道此项目是否接受捐赠，或者有什么别的地方可以帮忙的。