### PR TITLE
增加 Linux openjtalk 支持

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -113,7 +113,7 @@ $(document).ready(function() {
         var voices = window.speechSynthesis.getVoices();
         for (var i = 0; i < voices.length; i++) {
             var cur = voices[i];
-            if (cur.lang == "ja-JP") {
+            if (cur.lang == "ja-JP" || cur.lang == "ja") {
                 jp_index = i;
                 break;
             }


### PR DESCRIPTION
在 Linux 中使用 Open Jtalk 作为合成引擎，语言是 “ja” 而非 "ja-JP"。

<img width="717" height="248" alt="image" src="https://github.com/user-attachments/assets/fe6d4efc-6768-45f8-82bf-7dbaf73b218a" />

